### PR TITLE
DHFPROD-4180: Fixing entity-model-delete-trigger

### DIFF
--- a/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/controllers/model/ModelControllerTest.java
+++ b/marklogic-data-hub-central/src/test/java/com/marklogic/hub/central/controllers/model/ModelControllerTest.java
@@ -160,6 +160,9 @@ public class ModelControllerTest extends AbstractHubCentralTest {
         assertThrows(FailedRequestException.class, () -> controller.deleteModel("Entity2"), "Should throw an exception since the entity is referenced in steps.");
         removeReferencesToEntity();
         assertTrue(controller.deleteModel("Entity2").getStatusCode().is2xxSuccessful(), "Should be ok since we deleted the steps that refer to the entity.");
+
+        // Needed because a post-commit trigger is executed after a model is deleted
+        waitForTasksToFinish();
     }
 
     private JsonNode loadModel(DatabaseClient client) {

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-entity-model-writer.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/data-hub-entity-model-writer.json
@@ -2,18 +2,12 @@
   "role-name": "data-hub-entity-model-writer",
   "description": "Permits updating entity model documents",
   "role": [
-    "data-hub-common-writer",
-    "tde-admin"
+    "data-hub-common-writer"
   ],
   "privilege": [
     {
       "privilege-name": "any-uri",
       "action": "http://marklogic.com/xdmp/privileges/any-uri",
-      "kind": "execute"
-    },
-    {
-      "privilege-name": "rest-admin",
-      "action": "http://marklogic.com/xdmp/privileges/rest-admin",
       "kind": "execute"
     }
   ]

--- a/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/hub-central-entity-model-writer.json
+++ b/marklogic-data-hub/src/main/resources/hub-internal-config/security/roles/hub-central-entity-model-writer.json
@@ -10,6 +10,11 @@
       "privilege-name": "hub-central:writeEntityModel",
       "action": "http://marklogic.com/data-hub/hub-central/privileges/write-entity-model",
       "kind": "execute"
+    },
+    {
+      "privilege-name": "rest-admin",
+      "action": "http://marklogic.com/xdmp/privileges/rest-admin",
+      "kind": "execute"
     }
   ]
 }

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/4/triggers/entity-model-delete-trigger.xqy
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/4/triggers/entity-model-delete-trigger.xqy
@@ -2,25 +2,37 @@ xquery version '1.0-ml';
 
 import module namespace trgr = 'http://marklogic.com/xdmp/triggers' at '/MarkLogic/triggers.xqy';
 
-declare variable $ENTITY-MODEL-COLLECTION as xs:string := "http://marklogic.com/entity-services/models";
-declare variable $TDE-COLLECTION as xs:string := "http://marklogic.com/entity-services/models";
+declare namespace tde = "http://marklogic.com/xdmp/tde";
 
 declare variable $trgr:uri as xs:string external;
 
+let $tde-uri :=
+  let $entity-name := fn:replace($trgr:uri, "/entities/", "")
+  let $entity-name := fn:replace($entity-name, ".entity.json", "")
+  where $entity-name
+  return xdmp:invoke-function(
+    function() {
+      let $query := cts:and-query((
+        cts:collection-query("ml-data-hub-tde"),
+        cts:element-value-query(xs:QName("tde:context"), ".//" || $entity-name || "[node()]")
+      ))
+      return cts:uris((), ("limit=1"), $query)
+    }, map:entry("database", xdmp:schema-database())
+  )
+
 let $schema-xml-uri := fn:replace($trgr:uri, "\.json$", ".xsd")
 let $schema-json-uri := fn:replace($trgr:uri, "\.json$", ".schema.json")
+
 return (
   xdmp:invoke-function(
     function() {
-      if (fn:doc-available($trgr:uri)) then
-        xdmp:document-delete($trgr:uri)
-      else (),
-      if (fn:doc-available($schema-xml-uri)) then
-        xdmp:document-delete($schema-xml-uri)
-      else (),
-      if (fn:doc-available($schema-json-uri)) then
-        xdmp:document-delete($schema-json-uri)
-      else ()
+      for $uri in ($trgr:uri, $tde-uri, $schema-xml-uri, $schema-json-uri)
+      return
+        if (fn:doc-available($uri)) then (
+          xdmp:log("entity-model-delete-trigger.xqy: Deleting: " || $uri),
+          xdmp:document-delete($uri)
+        ) else
+          xdmp:log("entity-model-delete-trigger.xqy: Document not available, so not deleting: " || $uri)
     }, map:entry("database", xdmp:schema-database())
   )
-)
+);

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/4/triggers/entity-model-trigger.xqy
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/4/triggers/entity-model-trigger.xqy
@@ -28,8 +28,7 @@ let $entity-def-map as map:map := $entity-def
 
 let $schema-permissions := (
   xdmp:default-permissions(),
-  xdmp:permission("data-hub-developer", "update"),
-  xdmp:permission("data-hub-operator", "read"),
+  xdmp:permission("data-hub-common", "read"),
   xdmp:permission("data-hub-entity-model-writer", "update")
 )
 

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/models/deleteModel.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/data-services/models/deleteModel.sjs
@@ -38,4 +38,3 @@ if (steps.length) {
 
 entityLib.deleteModel(entityName);
 entityLib.deleteModelReferencesInOtherModels(entityModelUri, entityTypeId);
-entityLib.deleteModelRelatedTDE(entityName);

--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/entity-lib.sjs
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/5/impl/entity-lib.sjs
@@ -209,19 +209,6 @@ function deleteModel(entityName) {
   }
 }
 
-function deleteModelRelatedTDE(entityName) {
-  const entityModel = findModelByEntityName(entityName);
-  if (entityModel) {
-    const entityTitle = entityModel.info.title;
-    const entityVersion = entityModel.info.version;
-    const uri = "/tde/" + entityTitle + "-" + entityVersion + ".tdex";
-    const dataHub = DataHubSingleton.instance();
-    [dataHub.config.STAGINGDATABASE, dataHub.config.FINALDATABASE].forEach(db => {
-      dataHub.hubUtils.deleteDocument(uri, xdmp.invokeFunction(() => xdmp.databaseName(xdmp.schemaDatabase(xdmp.database(db)))));
-    });
-  }
-}
-
 /**
  * Returns the step names that contain a reference to the supplied entity.
  * The targetEntityType for mapping artifacts is checked against both an entityName or an entityTypeId.
@@ -369,7 +356,6 @@ function validateModelDefinitions(definitions) {
 
 module.exports = {
   deleteModel,
-  deleteModelRelatedTDE,
   findModelReferencesInSteps,
   findModelReferencesInOtherModels,
   deleteModelReferencesInOtherModels,


### PR DESCRIPTION
This simplifies 4180, as we don't need any additional code now to delete the TDE. 

Made one permissions fix in entity-model-trigger, but I am thinking that once the test is running as only hub-central-entity-model-writer, we'll need to fix the permissions on the trigger resource files so that they use data-hub-common instead of data-hub-operator.